### PR TITLE
Fix tracemaps rollback

### DIFF
--- a/database/migrations/2025_06_26_232204_create_tracemaps_table.php
+++ b/database/migrations/2025_06_26_232204_create_tracemaps_table.php
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('snaps');
+        Schema::dropIfExists('tracemaps');
     }
 };


### PR DESCRIPTION
## Summary
- fix tracemaps migration table name in down() method

## Testing
- `php artisan migrate --pretend` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d255812cc832f820f2eb1f2ac357a