### PR TITLE
Fix offline URL path in service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const CACHE_NAME = "offline-cache-v1";
-const OFFLINE_URL = 'public/offline.html';
+const OFFLINE_URL = '/offline.html';
 
 const filesToCache = [
     OFFLINE_URL,


### PR DESCRIPTION
## Summary
- use `/offline.html` instead of `public/offline.html` in service worker

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d255d5ee4832f873c036298c1a352