### PR TITLE
Remove snap_id reference from Media model

### DIFF
--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -13,7 +13,6 @@ class Media extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'snap_id',
         'tracemap_id',
         'file_path',
         'file_type',


### PR DESCRIPTION
## Summary
- clean up the Media model by removing the unused `snap_id` field

## Testing
- `grep -R "snap_id" -n --exclude-dir=.git || true`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686d25612ad0832fb2d524667025b400