### PR TITLE
Implement admin login

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminController extends Controller
+{
+    /**
+     * Display the login form for admin users.
+     */
+    public function showLoginForm()
+    {
+        return view('admin.login');
+    }
+
+    /**
+     * Handle an authentication attempt.
+     */
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+
+            return redirect()->intended('/');
+        }
+
+        return back()->withErrors([
+            'email' => __('auth.failed'),
+        ])->onlyInput('email');
+    }
+
+    /**
+     * Log the user out of the application.
+     */
+    public function logout(Request $request)
+    {
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('admin.login');
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'defaults' => [
+        'guard' => 'web',
+        'passwords' => 'users',
+    ],
+
+    'guards' => [
+        'web' => [
+            'driver' => 'session',
+            'provider' => 'users',
+        ],
+    ],
+
+    'providers' => [
+        'users' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\User::class,
+        ],
+    ],
+
+    'passwords' => [
+        'users' => [
+            'provider' => 'users',
+            'table' => 'password_reset_tokens',
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+    ],
+];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,9 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => 'password',
         ]);
     }
 }

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1 class="text-2xl mb-4">Admin Login</h1>
+    <form method="POST" action="{{ route('admin.login.post') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label for="email" class="block">Email</label>
+            <input id="email" type="email" name="email" value="{{ old('email') }}" required class="border rounded w-full p-2">
+            @error('email')
+                <div class="text-red-500 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
+        <div>
+            <label for="password" class="block">Password</label>
+            <input id="password" type="password" name="password" required class="border rounded w-full p-2">
+            @error('password')
+                <div class="text-red-500 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Login</button>
+    </form>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\App;
 use App\Http\Controllers\TracemapController;
+use App\Http\Controllers\AdminController;
 
 // Route principale qui redirige vers la page d'accueil des tracemaps
 Route::get('/', function () {
@@ -17,6 +18,10 @@ Route::post('/tracemaps', [TracemapController::class, 'store'])->name('tracemap.
 
 // Route pour le téléversement AJAX
 Route::post('/tracemaps/ajax', [TracemapController::class, 'storeAjax'])->name('tracemap.store.ajax');
+
+Route::get('/admin/login', [AdminController::class, 'showLoginForm'])->name('admin.login');
+Route::post('/admin/login', [AdminController::class, 'login'])->name('admin.login.post');
+Route::post('/admin/logout', [AdminController::class, 'logout'])->name('admin.logout');
 
 
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/AdminAuthTest.php
+++ b/tests/Feature/AdminAuthTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_login_and_logout(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($user);
+
+        $logout = $this->post('/admin/logout');
+        $logout->assertRedirect(route('admin.login'));
+        $this->assertGuest();
+    }
+
+    public function test_login_fails_with_invalid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+
+        $response = $this->from('/admin/login')->post('/admin/login', [
+            'email' => 'admin@example.com',
+            'password' => 'wrong',
+        ]);
+
+        $response->assertRedirect('/admin/login');
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,9 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
+use Tests\CreatesApplication;
+
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- add `AdminController` with basic login/logout
- define admin auth routes
- seed a default admin user
- create login blade view
- enable auth configuration
- add feature tests and testing helpers

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d29e4d96c832fa7b7d784d5af66de