### PR TITLE
Add maintenance mode management for admins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MAINTENANCE_SECRET=maintenance-secret

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Artisan;
+
+class AdminController extends Controller
+{
+    /**
+     * Enable maintenance mode with a secret bypass link.
+     */
+    public function enableMaintenance()
+    {
+        Artisan::call('down', ['secret' => config('app.maintenance_secret')]);
+
+        $url = url(config('app.maintenance_secret'));
+
+        return back()->with('success', "Maintenance mode enabled. Access via {$url}");
+    }
+
+    /**
+     * Disable maintenance mode.
+     */
+    public function disableMaintenance()
+    {
+        Artisan::call('up');
+
+        return back()->with('success', 'Maintenance mode disabled.');
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'maintenance_secret' => env('MAINTENANCE_SECRET'),
+];

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\App;
 use App\Http\Controllers\TracemapController;
+use App\Http\Controllers\AdminController;
 
 // Route principale qui redirige vers la page d'accueil des tracemaps
 Route::get('/', function () {
@@ -17,6 +18,12 @@ Route::post('/tracemaps', [TracemapController::class, 'store'])->name('tracemap.
 
 // Route pour le téléversement AJAX
 Route::post('/tracemaps/ajax', [TracemapController::class, 'storeAjax'])->name('tracemap.store.ajax');
+
+// Maintenance mode routes
+Route::middleware('auth')->group(function () {
+    Route::post('/maintenance/on', [AdminController::class, 'enableMaintenance'])->name('admin.maintenance.on');
+    Route::post('/maintenance/off', [AdminController::class, 'disableMaintenance'])->name('admin.maintenance.off');
+});
 
 
 

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class MaintenanceModeTest extends TestCase
+{
+    /** @test */
+    public function maintenance_mode_can_be_enabled_and_bypassed_with_secret(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('admin.maintenance.on'))
+            ->assertRedirect();
+
+        $this->assertTrue(app()->isDownForMaintenance());
+
+        $this->get('/')
+            ->assertStatus(503);
+
+        $secret = config('app.maintenance_secret');
+        $this->get('/' . $secret)->assertRedirect('/');
+
+        $this->get('/')->assertOk();
+
+        $this->post(route('admin.maintenance.off'))->assertRedirect();
+        $this->assertFalse(app()->isDownForMaintenance());
+    }
+}


### PR DESCRIPTION
## Summary
- allow toggling maintenance mode with secret bypass via `AdminController`
- store MAINTENANCE_SECRET in `config/app.php` and `.env.example`
- add maintenance routes protected by `auth`
- test maintenance mode secret bypass

## Testing
- `phpunit` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d29ea12a4832f859a8d475284d11f