### PR TITLE
Add tests for admin reset and maintenance features

### DIFF
--- a/tests/Feature/AdminResetDatabaseTest.php
+++ b/tests/Feature/AdminResetDatabaseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminResetDatabaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_reset_database(): void
+    {
+        // Assume an "admin" user exists
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)->post('/admin/reset-database');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_non_admin_cannot_reset_database(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/admin/reset-database');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $response = $this->post('/admin/reset-database');
+
+        $response->assertRedirect('/login');
+    }
+}

--- a/tests/Feature/MaintenanceModeTest.php
+++ b/tests/Feature/MaintenanceModeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MaintenanceModeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_enable_maintenance_and_get_secret_link(): void
+    {
+        $admin = \App\Models\User::factory()->create(['is_admin' => true]);
+
+        $response = $this->actingAs($admin)->post('/admin/maintenance/enable');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['secret']);
+    }
+
+    public function test_admin_can_disable_maintenance(): void
+    {
+        $admin = \App\Models\User::factory()->create(['is_admin' => true]);
+
+        $this->actingAs($admin)->post('/admin/maintenance/enable');
+
+        $response = $this->actingAs($admin)->post('/admin/maintenance/disable');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_guest_cannot_enable_maintenance(): void
+    {
+        $response = $this->post('/admin/maintenance/enable');
+
+        $response->assertRedirect('/login');
+    }
+}


### PR DESCRIPTION
## Summary
- add `AdminResetDatabaseTest` checking admin rights to reset the DB
- add `MaintenanceModeTest` verifying maintenance mode endpoints

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d29edcf2c832fa2ec2e7c5d0f8c1c