### PR TITLE
Add online count placeholder

### DIFF
--- a/resources/views/tracemap/index.blade.php
+++ b/resources/views/tracemap/index.blade.php
@@ -295,6 +295,13 @@
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
         }
 
+        /* Petit compteur d'utilisateurs en ligne */
+        #online-count {
+            font-size: 0.875rem; /* équivalent Tailwind text-sm */
+            color: #4B5563; /* équivalent Tailwind text-gray-600 */
+            margin-left: 0.5rem; /* équivalent Tailwind ml-2 */
+        }
+
         /* Styles pour les contrôles de la carte */
         .leaflet-control-layers {
             border-radius: 8px !important;
@@ -359,7 +366,9 @@
          data-intro="TraceMap vous permet de partager des photos et vidéos liées à des lieux spécifiques sur la carte."
          data-step="2">
         <div class="flex items-center justify-between">
-            <h1 class="text-xl font-bold text-gray-800">TraceMap</h1>
+            <h1 class="text-xl font-bold text-gray-800">TraceMap
+                <span id="online-count" class="text-sm text-gray-600 ml-2"></span>
+            </h1>
             <button id="restart-tutorial" class="text-sm text-blue-600 hover:text-blue-800 flex items-center ml-4">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24"
                      stroke="currentColor">


### PR DESCRIPTION
## Summary
- add an empty online user count span next to TraceMap title
- include simple styling for the new element

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d50b57660832f829360dff3683ecc