### PR TITLE
Allow guest access to broadcasting auth

### DIFF
--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -12,8 +12,7 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Broadcast::routes();
+        Broadcast::routes(['middleware' => ['web']]);
 
         require base_path('routes/channels.php');
-    }
-}
+    }}

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Str;
 
 /*
 |--------------------------------------------------------------------------
@@ -18,9 +19,22 @@ Broadcast::channel('tracemap-updates', function () {
     return true; // Canal public, accessible à tous
 });
 
-// Presence channel for tracemap users
+// Presence channel for tracemap users with guest support
 Broadcast::channel('tracemap-presence', function ($user) {
-    return [
-        'id' => $user->id,
-        'name' => $user->name,
-    ];});
+    if ($user) {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+        ];
+    }
+
+    $guest = session('guest_id');
+    if (! $guest) {
+        $guest = 'guest-' . Str::random(8);
+        session(['guest_id' => $guest]);
+    }
+
+    return [        'id' => $guest,
+        'name' => 'Guest',
+    ];
+});


### PR DESCRIPTION
## Summary
- expose broadcasting routes to guest users
- add anonymous user support in `tracemap-presence` channel

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d60307508832f90671395d16f1467